### PR TITLE
District boundary visibility

### DIFF
--- a/css/ryht-legislative-style.css
+++ b/css/ryht-legislative-style.css
@@ -86,10 +86,11 @@ img {
 }
 
 .stats {
-	display: none;
-	background-color: #ffffff;
-	opacity:.8;
-	border: 1px solid #989797;
+	opacity: 0;
+	transition: opacity 1.5s;
+	-webkit-transition: opacity 1.5s;
+	background-color: rgba(255, 255, 255, 0.7);
+	border: 1px solid rgba(152, 151, 151, 1);
 	width: 225px;
 	text-align: left;
 	padding: 10px;
@@ -100,7 +101,7 @@ img {
 	bottom: 10;
 	font-family: "Montserrat", helvetica, arial, sans-serif;
 	font-weight: normal;
-	color: #363635;
+	color: rgba(54, 54, 53, 1);
 	text-decoration: none;
 	margin-right: 10px;
 	margin-top: 10px;

--- a/css/ryht-legislative-style.css
+++ b/css/ryht-legislative-style.css
@@ -65,48 +65,41 @@ img {
 	overflow: hidden; /*planning ahead to clear floats*/
 }
 
-.legend {
-	background-color: #ffffff;
-	opacity:.8;
-	border: 1px solid #989797;
+.legend, .stats {
+	background-color: rgba(255, 255, 255, 0.7);
+	border: 1px solid rgba(190, 188, 188, 1);
+	color: rgba(82, 82, 80, 1);
 	width: 225px;
-	text-align: left;
-	padding: 10px;
-    position: fixed;
-	z-index : 1;
-    right: 0;
-	bottom: 0;
-	font-family: "Montserrat", helvetica, arial, sans-serif;
 	font-weight: normal;
-	color: #363635;
 	text-decoration: none;
+	overflow: hidden; /*planning ahead to clear floats*/
+	font-family: "Montserrat", helvetica, arial, sans-serif;
+	text-align: left;
+}
+
+.legend {
+	padding: 10px;
+  position: fixed;
+	z-index: 1;
+  right: 0;
+	bottom: 0;
 	margin-right: 10px;
 	margin-bottom: 20px;
-	overflow: hidden; /*planning ahead to clear floats*/
 }
 
 .stats {
 	opacity: 0;
 	transition: opacity 1.5s;
 	-webkit-transition: opacity 1.5s;
-	background-color: rgba(255, 255, 255, 0.7);
-	border: 1px solid rgba(190, 188, 188, 1);
-	width: 225px;
-	text-align: left;
 	padding: 10px;
 	padding-right: 0px;
-    position: fixed;
+  position: fixed;
 	z-index : 1;
-    right: 0;
+  right: 0;
 	bottom: 10;
-	font-family: "Montserrat", helvetica, arial, sans-serif;
-	font-weight: normal;
-	color: rgba(82, 82, 80, 1);
-	text-decoration: none;
 	margin-right: 10px;
 	margin-top: 10px;
 /*	margin-bottom: 20px; */
-	overflow: hidden; /*planning ahead to clear floats*/
 }
 
 .stats-title {

--- a/css/ryht-legislative-style.css
+++ b/css/ryht-legislative-style.css
@@ -90,7 +90,7 @@ img {
 	transition: opacity 1.5s;
 	-webkit-transition: opacity 1.5s;
 	background-color: rgba(255, 255, 255, 0.7);
-	border: 1px solid rgba(152, 151, 151, 1);
+	border: 1px solid rgba(190, 188, 188, 1);
 	width: 225px;
 	text-align: left;
 	padding: 10px;
@@ -101,7 +101,7 @@ img {
 	bottom: 10;
 	font-family: "Montserrat", helvetica, arial, sans-serif;
 	font-weight: normal;
-	color: rgba(54, 54, 53, 1);
+	color: rgba(82, 82, 80, 1);
 	text-decoration: none;
 	margin-right: 10px;
 	margin-top: 10px;
@@ -109,23 +109,23 @@ img {
 	overflow: hidden; /*planning ahead to clear floats*/
 }
 
-  .stats-title {
+.stats-title {
 	position:relative;
 	bottom:0;
 	right:0;
-    text-align: left;
-    margin-bottom: 5px;
+  text-align: left;
+  margin-bottom: 5px;
 	font-family: "Montserrat", helvetica, arial, sans-serif;
-    font-weight: bold;
-    font-size: 90%;
-    }
-  .stats .stats-scale ul {
-    margin: 0;
-    margin-bottom: 5px;
-    padding: 0;
-    float: left;
-    list-style: none;
-    }
+  font-weight: bold;
+  font-size: 90%;
+}
+.stats .stats-scale ul {
+   margin: 0;
+   margin-bottom: 5px;
+   padding: 0;
+   float: left;
+   list-style: none;
+}
   .stats .stats-scale ul li {
     font-size: 75%;
     list-style: none;

--- a/css/ryht-legislative-style.css
+++ b/css/ryht-legislative-style.css
@@ -86,6 +86,7 @@ img {
 }
 
 .stats {
+	display: none;
 	background-color: #ffffff;
 	opacity:.8;
 	border: 1px solid #989797;
@@ -358,7 +359,7 @@ p.moreinfo  {
   font-size:14px;
  /* width:auto !important;*/
   }
-  
+
   p.programs  {
   padding: 8px 8px 8px 32px;
   background: #ffff;
@@ -367,7 +368,7 @@ p.moreinfo  {
   font-size:10px;
  /* width:auto !important;*/
   }
-  
+
  .sidenav .programlink {
     /*padding: 8px 8px 8px 32px;*/
     text-decoration: none;
@@ -375,7 +376,7 @@ p.moreinfo  {
     font-size: 10px;
     color: #ee5e2a;
     transition: 0.3s
-} 
+}
 
  .content .programlink {
     /*padding: 8px 8px 8px 32px;*/
@@ -384,7 +385,7 @@ p.moreinfo  {
     font-size: 10px;
     color: #ee5e2a;
     transition: 0.3s
-} 
+}
 
 .sidenav a {
     /*padding: 8px 8px 8px 32px;*/

--- a/index.html
+++ b/index.html
@@ -674,7 +674,7 @@
 							'polygonLayerName': 'state-senate-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.	Leave out or set to false if you don't want one.
 							'polygonFillColor': 'rgba(200, 100, 240, 0)', // colour to fill polygons with. Needed if there's going to be a polygon layer; simply leave out if not.
 							'polygonOutlineColor': 'rgba(200, 100, 240, 0)', // colour to draw polygon boundaries with. Needed if there's going to be a polygon layer; simply leave out if not.
-							'visibleOnLoad': false, // set this optional argument to true to have the layer visible on load. Leave out or set to false to have it hidden on load
+							'visibleOnLoad': true, // set this optional argument to true to have the layer visible on load. Leave out or set to false to have it hidden on load
 							'usedInZoomControl': true // set this optional argument to true if this layer will be used in the Zoom to Districts control, otherwise leave it out or set it to false.
 						}
 					);
@@ -694,6 +694,7 @@
 							'polygonLayerName': 'state-house-districts-poly',
 							'polygonFillColor': 'rgba(200, 100, 240, 0)',
 							'polygonOutlineColor': 'rgba(200, 100, 240, 0)',
+							'visibleOnLoad': true,
 							'usedInZoomControl': true
 						}
 					);

--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
 
 			function zoomToPolygon(sourceID, coords, filterField) {
 				if (typeof coords !== 'undefined') {
-					document.getElementById('statsBox').style.display = "none";
+					document.getElementById('statsBox').style.opacity = 0;
 					coords = coords.split(",");
 					bbox = [
 						[coords[0], coords[1]],
@@ -259,7 +259,7 @@
 			}
 
 			function updateStatsBox(districtType, districtID) {
-				document.getElementById('statsBox').style.display = "block";
+				document.getElementById('statsBox').style.opacity = 1;
 				if (districtType.indexOf("house") > -1) {
 					document.getElementById("stats.districtType").innerText = "House";
 				} else if (districtType.indexOf("senate") > -1) {

--- a/index.html
+++ b/index.html
@@ -277,6 +277,34 @@
 					document.getElementById(counterID).innerText = pointsInDistrict.length;
 				}
 			}
+
+			function standardizeCase(txt) {
+				console.log("INPUT", txt);
+				if (txt === undefined || txt === "") {
+					return "";
+				} else {
+					txt = txt.replace(/([^\W_]+[^\s-]*) */g, function(x) {
+						return x.charAt(0).toUpperCase() + x.substr(1).toLowerCase();
+					});
+					txt = " " + txt + " ";
+	// NB: always include the leading & trailing spaces in this list to avoid accidentally selecting substrings.  The .trim() call at the end will clean them back up.
+					overrides = [
+						[" Isd ", " ISD "],
+						[" Cisd ", " CISD "],
+						[" El ", " Elementary "],
+						[" Pri ", " Primary "],
+						[" J H ", " Junior High" ],
+						[" Int ", " Intermediate "],
+						[" H S ", " High "],
+						[" Aec ", " Alternative Education Center "]
+					];
+					for (i in overrides) {
+						txt = txt.replace(overrides[i][0], overrides[i][1]);
+					}
+					console.log("OUTPUT", txt);
+					return txt.trim();
+				}
+			}
 		</script>
 	</head>
 
@@ -748,7 +776,7 @@
 
 			function fillpopup_rfp(data){
 				var html_rfp = "";
-				html_rfp = html_rfp + "<span class='varname'>School: </span> <span class='attribute'>" + data.account_name + "</span>";
+				html_rfp = html_rfp + "<span class='varname'>School: </span> <span class='attribute'>" + standardizeCase(data.account_name) + "</span>";
 				return html_rfp;
 				//this will return the string to the calling function
 
@@ -831,9 +859,9 @@
 				var html = "";
 				html = html + "<span class='varname'>Institute: </span> <span class='attribute'>" + data.institute + "</span>";
 				html = html + "<br />"
-				html = html + "<span class='varname'>Campus: </span> <span class='attribute'>" + data.campus + "</span>";
+				html = html + "<span class='varname'>Campus: </span> <span class='attribute'>" + standardizeCase(data.campus) + "</span>";
 				html = html + "<br />"
-				html = html + "<span class='varname'>School District: </span> <span class='attribute'>" + data.district + "</span>";
+				html = html + "<span class='varname'>School District: </span> <span class='attribute'>" + standardizeCase(data.district) + "</span>";
 				return html;
 				//this will return the string to the calling function
 

--- a/index.html
+++ b/index.html
@@ -218,6 +218,17 @@
 						setTimeout(function(){
 							for (i in loadedPolygonLayers) {
 								showHideLayer(loadedPolygonLayers[i][0], loadedPolygonLayers[i][1], showOnly=true);
+								if (
+									(loadedPolygonLayers[i][0].indexOf("state-senate-districts") > -1)
+									||
+									(loadedPolygonLayers[i][0].indexOf("state-house-districts") > -1)
+								) {
+									console.log(loadedPolygonLayers[i], coords[4], map.queryRenderedFeatures( { layers:[loadedPolygonLayers[i][0]] } ));
+									map.setFilter(
+										loadedPolygonLayers[i][0],
+										['!=', 'District', coords[4]]
+									);
+								}
 							}
 							for (i in loadedPointLayers) {
 								map.setFilter(

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
 								);
 								showHideLayer(loadedPointLayers[i][0], loadedPointLayers[i][1], showOnly=true);
 							}
-							for (i = 300; i <= 2100; i += 300) {
+							for (i = 500; i <= 2500; i += 500) {
 								setTimeout(function(){
 									updateStatsBox(filterField, coords[4]);
 								}, i);

--- a/index.html
+++ b/index.html
@@ -229,6 +229,7 @@
 
 			function zoomToPolygon(sourceID, coords, filterField) {
 				if (typeof coords !== 'undefined') {
+					document.getElementById('statsBox').style.display = "none";
 					coords = coords.split(",");
 					bbox = [
 						[coords[0], coords[1]],
@@ -258,6 +259,7 @@
 			}
 
 			function updateStatsBox(districtType, districtID) {
+				document.getElementById('statsBox').style.display = "block";
 				if (districtType.indexOf("house") > -1) {
 					document.getElementById("stats.districtType").innerText = "House";
 				} else if (districtType.indexOf("senate") > -1) {
@@ -375,7 +377,7 @@
 				This bit of code creates the temporary window that appears above the legend
 				and displays the summary stats for the selected district-->
 
-			<div class='stats'>
+			<div class='stats' id='statsBox'>
 				<div class='stats-title'>
 					Number of Programs in
 					<br />

--- a/index.html
+++ b/index.html
@@ -127,10 +127,8 @@
 					if (urlParams["zoomto"] && urlParams["zoomto"].toString() === polygons[i].name.toString()) {
 						if (showHouseDistricts) {
 							zoomToPolygon(sourceID, polygons[i].bbox.toString() + ',' + polygons[i].name, 'house_dist');
-							showHideLayer('state-house-districts-lines', markerName='state_house_districts', showOnly=true);
 						} else if (showSenateDistricts) {
 							zoomToPolygon(sourceID, polygons[i].bbox.toString() + ',' + polygons[i].name, 'senate_dist');
-							showHideLayer('state-senate-districts-lines', markerName='state_senate_districts', showOnly=true);
 						}
 					}
 				}
@@ -235,6 +233,11 @@
 						[coords[0], coords[1]],
 						[coords[2], coords[3]]
 					];
+					if (showHouseDistricts) {
+						showHideLayer('state-house-districts-lines', markerName='state_house_districts', showOnly=true);
+					} else if (showSenateDistricts) {
+						showHideLayer('state-senate-districts-lines', markerName='state_senate_districts', showOnly=true);
+					}
 					map.fitBounds(bbox, options={padding: 10, duration: 3000});
 					if (filterField !== undefined) {
 						setTimeout(function(){
@@ -248,7 +251,7 @@
 									console.log(loadedPolygonLayers[i], coords[4], map.queryRenderedFeatures( { layers:[loadedPolygonLayers[i][0]] } ));
 									map.setFilter(
 										loadedPolygonLayers[i][0],
-										['!=', 'District', coords[4]]
+										['==', 'District', coords[4]]
 									);
 								}
 							}

--- a/index.html
+++ b/index.html
@@ -39,14 +39,32 @@
 			var showHouseDistricts = true;
 			var showSenateDistricts = false;
 			if (
-				(urlParams["districts"] && urlParams["districts"].toLowerCase().indexOf("sen") > -1) ||
-				(urlParams["display"] && urlParams["display"].toLowerCase().indexOf("sen") > -1) ||
-				(urlParams["Districts"] && urlParams["Districts"].toLowerCase().indexOf("sen") > -1) ||
-				(urlParams["Display"] && urlParams["Display"].toLowerCase().indexOf("sen") > -1) ||
-				(urlParams["districts"] && urlParams["districts"].toLowerCase() === 's') ||
-				(urlParams["display"] && urlParams["display"].toLowerCase() === 's') ||
-				(urlParams["Districts"] && urlParams["Districts"].toLowerCase() === 's') ||
-				(urlParams["Display"] && urlParams["Display"].toLowerCase() === 's')			) {
+				(
+					urlParams["districts"] && (
+						urlParams["districts"].toLowerCase().indexOf("sen") > -1
+						||
+						urlParams["districts"].toLowerCase() === 's'
+					)
+				) || (
+					urlParams["Districts"] && (
+						urlParams["Districts"].toLowerCase().indexOf("sen") > -1
+						||
+						urlParams["Districts"].toLowerCase() === 's'
+					)
+				) || (
+					urlParams["display"] && (
+						urlParams["display"].toLowerCase().indexOf("sen") > -1
+						||
+						urlParams["display"].toLowerCase() === 's'
+					)
+				) || (
+					urlParams["Display"] && (
+						urlParams["Display"].toLowerCase().indexOf("sen") > -1
+						||
+						urlParams["Display"].toLowerCase() === 's'
+					)
+				)
+			) {
 				showHouseDistricts = false;
 				showSenateDistricts = true;
 			}


### PR DESCRIPTION
This one's actually a tiny change, as will be clear if you merge https://github.com/coregis/ryht-legislative/pull/12 & https://github.com/coregis/ryht-legislative/pull/13 first.

Here's what I still have left on my list:

* highlight the zoomed-to district
* add switch to house|senate districts link under the zoomto dropdown (show both options)
* can we turn the "State House|Senate Districts" item at the top of the zoom-to- dropdown into a zoom back out to the whole state option?
* can I make zoom actions always update the URL?

I should have some time tomorrow; otherwise I definitely will on Wednesday.