### PR TITLE
Better timing of events that need to wait for all layers to load

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 	//zoomToPolygon() zooms the map to the district extent
 
 			function runWhenLoadComplete() {
-				if (!map.loaded()) {
+				if (!map.getLayer('raising-school-leaders-points')) {
 					setTimeout(runWhenLoadComplete, 100);
 				}
 				else {
@@ -113,7 +113,7 @@
 						map.moveLayer('raising-blended-learners-campuses-points', 'raising-texas-teachers-points');
 						map.moveLayer('raising-school-leaders-points', 'raising-blended-learners-points');
 						map.moveLayer('raising-school-leaders-points', 'charles-butt-scholars-points');
-					}, 2000);
+					}, 100);
 				}
 			}
 


### PR DESCRIPTION
I think the bug causing some layers to fail to load was actually a timing one, in that the zoom event was running before mapbox had finished loading all the layers.  So I figured out how to make `runWhenLoadComplete()` wait for the largest data layer to load, instead of just the `map.loaded()` event.  I _think_ this should resolve that glitch, but it's definitely worth doing more testing.  

So far, when I fake a really slow connection using https://blog.nightly.mozilla.org/2016/11/07/simulate-slow-connections-with-the-network-throttling-tool/ I'm finding that it takes some time for the zoom to happen, presumably because it's sitting there waiting for that layer to finish loading, but then when it does zoom everything actually displays correctly.

One drawback of this approach is that if another layer loads slower that RSL it may still be missed.  But at the moment RSL seems to have an order of magnitude more data than any other, _and_ it's the last of the point layers to be loaded anyway, so I think this should be safe unless the data changes significantly.